### PR TITLE
Export extra connection methods.

### DIFF
--- a/core/Network/DBus.hs
+++ b/core/Network/DBus.hs
@@ -13,7 +13,7 @@ module Network.DBus
       establish
     , establishWithCatchall
     , disconnect
-    , DBusConnection
+    , DBusConnection(..)
     -- * Types
     , DBusMessageable(..)
     , DBusCall(..)

--- a/core/Network/DBus/Actions.hs
+++ b/core/Network/DBus/Actions.hs
@@ -12,8 +12,11 @@ module Network.DBus.Actions
     , authenticate
     , authenticateUID
 
-    , connectSession
     , connectSystem
+    , connectSession
+    , connectTo
+    , connectOver
+    , connectUnix
     , contextNew
     , contextNewWith
 
@@ -142,15 +145,15 @@ connectOver "unix" flags = do
 
 connectOver _ _ = error "not implemented yet"
 
-connectSessionAt :: ByteString -> IO Handle
-connectSessionAt addr = do
+connectTo :: ByteString -> IO Handle
+connectTo addr = do
     let (domain, flagstr) = second BC.tail $ BC.breakSubstring ":" addr
     let flags = map (\x -> let (k:v:[]) = BC.split '=' x in (k,v)) $ BC.split ',' flagstr
     connectOver domain flags
 
 -- | connect to the dbus session bus define by the environment variable DBUS_SESSION_BUS_ADDRESS
 connectSession :: IO Handle
-connectSession = BC.pack <$> getEnv "DBUS_SESSION_BUS_ADDRESS" >>= connectSessionAt
+connectSession = BC.pack <$> getEnv "DBUS_SESSION_BUS_ADDRESS" >>= connectTo
 
 -- | connect to the dbus system bus
 connectSystem :: IO Handle


### PR DESCRIPTION
In order to talk to PulseAudio, I need to connect directly to `"unix:path=/run/user/1000/pulse/dbus-socket"` (the actual socket path being retrieved from the PulseAudio discovery service via the session bus.) This is why I've found it necessary to export `connectTo` (formerly `connectSessionAt`) as well as its buddies `connectOver` and `connectUnix`.
